### PR TITLE
Multi sync management command

### DIFF
--- a/dimagi/requirements.txt
+++ b/dimagi/requirements.txt
@@ -1,0 +1,6 @@
+restkit==3.2.1
+couchdbkit==0.5.7
+django==1.3.1
+gevent==0.13.8
+greenlet==0.4.0
+


### PR DESCRIPTION
new management command sync_prepare_couchdb_multi (moved from corehq)

requires gevent, optional gitpython for current checkout info summary.

python manage.py sync_prepare_couchdb_multi <num_threads> <username>

both args optional, defaults to 4, username hard codes to email to commcarehq-dev@dimagi.com on results.

this took a bit longer to get working due to exceptions being thrown on long running reindex tasks (see: reports).  I believe the exceptions happen due to COUCHDB_TIMEOUT which is defaulted to 5 minutes. I don't want to have to expand the timeout for long running tasks running away, so I had to add a secondary checker using the server's active_tasks feed and force the number of workers to be below that.
