### PR TITLE
Update send_HTML_email for Django 1.4

### DIFF
--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.mail import SMTPConnection
+from django.core.mail import get_connection
 from django.core.mail.message import EmailMultiAlternatives
 
 NO_HTML_EMAIL_MESSAGE = """
@@ -26,7 +26,8 @@ def send_HTML_email(subject, recipient, html_content, text_content=None):
     if email_from is None:
         email_from = email_return_path
     from_header = {'From': email_from}  # From-header
-    connection = SMTPConnection(username=settings.EMAIL_LOGIN,
+    connection = get_connection(backend='django.core.mail.backends.smtp.EmailBackend',
+                                username=settings.EMAIL_LOGIN,
                                 port=settings.EMAIL_SMTP_PORT,
                                 host=settings.EMAIL_SMTP_HOST,
                                 password=settings.EMAIL_PASSWORD,


### PR DESCRIPTION
While working on some updates for email-reports I noticed that `send_HTML_email` was using `SMTPConnection` which was deprecated in 1.2 and removed in 1.4. This updates the function to use `get_connection` instead per the docs https://docs.djangoproject.com/en/1.3/topics/email/#django.core.mail.get_connection. It's worth noting that this drops Django 1.1 support.
