### PR TITLE
Added optional headers parameter to simple_post()

### DIFF
--- a/dimagi/utils/post.py
+++ b/dimagi/utils/post.py
@@ -42,16 +42,16 @@ def tmpfile(*args, **kwargs):
     return (os.fdopen(fd, 'w'), path)
 
 
-def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
+def simple_post(data, url, content_type="text/xml", timeout=60, headers={}}):
     """
     POST with a cleaner API, and return the actual HTTPResponse object, so
     that error codes can be interpreted.
     """
-    if headers is None:
-        headers = {
-            "content-type": content_type,
-            "content-length": len(data),
-        }
+    default_headers = {
+        "content-type": content_type,
+        "content-length": len(data),
+    }
+    default_headers.update(headers)
             
     up = urlparse(url)
     if url.startswith("https"):
@@ -59,7 +59,7 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
     else:
         Connection = httplib.HTTPConnection
     conn = Connection(up.netloc, timeout=timeout)
-    conn.request('POST', up.path, data, headers)
+    conn.request('POST', up.path, data, default_headers)
     return conn.getresponse()
 
 


### PR DESCRIPTION
Useful for passing custom headers. Used to fix the case https://github.com/dimagi/commcare-hq/pull/425 (Add "received_on" header to the form forwarding API)
