### PR TITLE
add LazyAttachmentDoc and tests

### DIFF
--- a/dimagi/utils/couch/lazy_attachment_doc.py
+++ b/dimagi/utils/couch/lazy_attachment_doc.py
@@ -1,0 +1,74 @@
+from couchdbkit.ext.django.schema import Document
+
+
+class LazyAttachmentDoc(Document):
+
+    def __store_lazy_attachment(self, content, name=None, content_type=None,
+                                content_length=None):
+        if not hasattr(self, '_LAZY_ATTACHMENTS'):
+            self._LAZY_ATTACHMENTS = {}
+        info = {
+            'content': content,
+            'content_type': content_type,
+            'content_length': content_length,
+        }
+        self._LAZY_ATTACHMENTS[name] = info
+        return info
+
+    def put_attachment(self, content, name=None, content_type=None,
+                       content_length=None):
+        info = self.__store_lazy_attachment(content, name, content_type,
+                                            content_length)
+        return super(LazyAttachmentDoc, self).put_attachment(name=name, **info)
+
+    def lazy_put_attachment(self, content, name=None, content_type=None,
+                            content_length=None):
+        """
+        Ensure the attachment is available through lazy_fetch_attachment
+        and that upon self.save(), the attachments are put to the doc as well
+
+        """
+        info = self.__store_lazy_attachment(content, name, content_type,
+                                            content_length)
+
+        def put_attachment():
+            self.put_attachment(name=name, **info)
+
+        self.register_post_save(put_attachment)
+
+    def lazy_fetch_attachment(self, name):
+        if not hasattr(self, '_LAZY_ATTACHMENTS'):
+            self._LAZY_ATTACHMENTS = {}
+        try:
+            return self._LAZY_ATTACHMENTS[name]['content']
+        except KeyError:
+            return self.fetch_attachment(name)
+
+
+    def register_pre_save(self, fn):
+        if not hasattr(self, '_PRE_SAVE'):
+            self._PRE_SAVE = []
+        self._PRE_SAVE.append(fn)
+
+    def register_post_save(self, fn):
+        if not hasattr(self, '_POST_SAVE'):
+            self._POST_SAVE = []
+        self._POST_SAVE.append(fn)
+
+    def save(self, **params):
+        if hasattr(self, '_PRE_SAVE'):
+            for pre_save in self._PRE_SAVE:
+                pre_save()
+
+            def del_pre_save():
+                del self._PRE_SAVE
+
+            self.register_post_save(del_pre_save)
+
+        super(LazyAttachmentDoc, self).save(**params)
+
+        if hasattr(self, '_POST_SAVE'):
+            for post_save in self._POST_SAVE:
+                post_save()
+
+            del self._POST_SAVE

--- a/dimagi/utils/tests/__init__.py
+++ b/dimagi/utils/tests/__init__.py
@@ -1,6 +1,6 @@
 from dimagi.utils.create_unique_filter import create_unique_filter
-from excel import IteratorJSONReader
-from decorators.memoized import Memoized
+from dimagi.utils.excel import IteratorJSONReader
+from dimagi.utils.decorators.memoized import Memoized
 from dimagi.utils.chunked import chunked
 
 __test__ = {
@@ -9,3 +9,5 @@ __test__ = {
     'chunked': chunked,
     'create_unique_filter': create_unique_filter,
 }
+
+from lazy_attachment_doc import *

--- a/dimagi/utils/tests/lazy_attachment_doc.py
+++ b/dimagi/utils/tests/lazy_attachment_doc.py
@@ -1,0 +1,43 @@
+from couchdbkit.ext.django.schema import StringProperty
+from django.test import TestCase
+from dimagi.utils.couch.lazy_attachment_doc import LazyAttachmentDoc
+
+
+class SampleDoc(LazyAttachmentDoc):
+
+    name = StringProperty()
+
+
+class LazyAttachmentDocTest(TestCase):
+
+    def setUp(self):
+        self.sample = SampleDoc(name='test sample doc')
+
+    def test_put_lazy_attachment(self):
+        content = 'this is my content'
+        content2 = 'this is my content2'
+        name = 'content.txt'
+
+        def test(content, prev_content=None):
+            self.sample.lazy_put_attachment(content, name=name)
+            self.assertEqual(self.sample.lazy_fetch_attachment(name), content)
+            if prev_content:
+                self.assertEqual(self.sample.fetch_attachment(name),
+                                 prev_content)
+            else:
+                with self.assertRaises(KeyError):
+                    self.sample.fetch_attachment(name)
+            self.sample.save()
+            self.assertEqual(self.sample.fetch_attachment(name), content)
+            self.assertEqual(self.sample.lazy_fetch_attachment(name), content)
+            self.assertEqual(
+                SampleDoc.get(self.sample.get_id).fetch_attachment(name),
+                content
+            )
+            self.assertEqual(
+                SampleDoc.get(self.sample.get_id).lazy_fetch_attachment(name),
+                content
+            )
+
+        test(content)
+        test(content2, prev_content=content)

--- a/settings.py
+++ b/settings.py
@@ -27,7 +27,7 @@ COUCH_DATABASE_NAME = 'dimagi_utils'
 
 COUCH_DATABASE = 'http://127.0.0.1:5984/dimagi_utils_test'
 
-COUCHDB_DATABASES = [(app, 'http://127.0.0.1:5984/dimagi_utils') for app in ['utils', 'couch']]
+COUCHDB_DATABASES = [(app, 'http://127.0.0.1:5984/dimagi_utils') for app in ['utils', 'couch', 'tests']]
 
 
 # Hardcode the test database?


### PR DESCRIPTION
to be used in app manager for building apps
or any situation where you want to make changes
to a doc interspersed with adding attachments
and then finally save it once
at which point the doc is first saved
and then the attachments are put to the doc
