### PR TITLE
Switch to Pillow from PIL

### DIFF
--- a/dimagi/test_utils/cache_tests.py
+++ b/dimagi/test_utils/cache_tests.py
@@ -1,12 +1,11 @@
 import os
 import StringIO
 
+from PIL import Image
 from unittest2 import TestCase
 
 from dimagi.utils.django import cached_object
 from dimagi.utils.django.cached_object import CachedObject, CachedImage, IMAGE_SIZE_ORDERING, OBJECT_ORIGINAL
-import Image
-
 
 class FakeCache(object):
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'couchdbkit',
         'django_redis',
         'simplejson',
-        'PIL'
+        'Pillow'
     ],
     tests_require=[
         'unittest2',


### PR DESCRIPTION
Something seems to have gone awry with PIL on pypi. This switches to an alternate distribution called Pillows. The tests still pass and coverage of the file that involves imaging is good, so I think it ought to be OK. However, risk of breakage seems high so let's be careful.
