### PR TITLE
Move unittest2 and mock into hard deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
  - "sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib"
  - "pip install -e . --use-mirrors"
  - "pip install coverage coveralls --use-mirrors"
- - "pip install unittest2 mock"
 script:
 - "coverage run --parallel-mode `which django-admin.py` test --settings settings --traceback utils"
 - "coverage run --parallel-mode setup.py test"

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,15 @@ setup(
     test_suite='dimagi.test_utils',
     test_loader='unittest2:TestLoader',
     install_requires=[
+        'couchdbkit',
         'django',
+        'django_redis',
+        'mock>=0.8.0',
         'openpyxl',
+        'Pillow',
         'python-dateutil',
         'pytz',
-        'couchdbkit',
-        'django_redis',
         'simplejson',
-        'Pillow'
-    ],
-    tests_require=[
         'unittest2',
-        'mock>=0.8.0',
     ],
 )


### PR DESCRIPTION
For django apps, anything the tests require is a hard dep, because tests are within the distributed code.
