### PR TITLE
add "1" and "0" to true/false strings (Case:66266)

### DIFF
--- a/dimagi/utils/parsing.py
+++ b/dimagi/utils/parsing.py
@@ -1,8 +1,8 @@
 from datetime import datetime, date, time
 from dateutil.parser import parse
 
-TRUE_STRINGS = ("true", "t", "yes", "y")
-FALSE_STRINGS = ("false", "f", "no", "n")
+TRUE_STRINGS = ("true", "t", "yes", "y", "1")
+FALSE_STRINGS = ("false", "f", "no", "n", "0")
 
 def string_to_boolean(val):
     """


### PR DESCRIPTION
i never totally tracked down how these are getting called with a "1" and "0" (suspect some strange True->1 conversion jython edge case?) but this seems like a reasonable workaround
