### PR TITLE
fail-fast when header is not a string

### DIFF
--- a/dimagi/utils/excel.py
+++ b/dimagi/utils/excel.py
@@ -88,7 +88,7 @@ class IteratorJSONReader(object):
         obj = {}
         for field, value in zip(self.headers, [''] * len(self.headers)):
             if not isinstance(field, basestring):
-                raise HeaderValueError("Field " + str(field) + " is not a string.")
+                raise HeaderValueError(u'Field %s is not a string.' % field)
             self.set_field_value(obj, field, value)
         return obj.keys()
 


### PR DESCRIPTION
Part of fixing: http://manage.dimagi.com/default.asp?84153#484866
