### PR TITLE
no longer log every redis cache miss

### DIFF
--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -196,8 +196,8 @@ class CachedObject(object):
                 return False
             else:
                 return True
-        except AssertionError as e:
-            logging.exception(e.message)
+        except AssertionError:
+            # maybe one of our keys was purged. Oh well.
             return False
 
     @property


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?101680

looked into this a bit. this is an error that gets raised when the actual data and metadata for a given cache key in redis don't match up.

i'm guessing this is happening because of how redis purges keys (in a random fashion):

from: http://redis.io/commands/expire

How Redis expires keys
Redis keys are expired in two ways: a passive way, and an active way.
A key is actively expired simply when some client tries to access it, and the key is found to be timed out.
Of course this is not enough as there are expired keys that will never be accessed again. This keys should be expired anyway, so periodically Redis test a few keys at random among keys with an expire set. All the keys that are already expired are deleted from the keyspace.
Specifically this is what Redis does 10 times per second:
Test 100 random keys from the set of keys with an associated expire.
Delete all the keys found expired.
If more than 25 keys were expired, start again from step 1.

So my proposal is to just stop logging this error
