### PR TITLE
Use duck-typing to support Django debug toolbar

### DIFF
--- a/dimagi/utils/couch/cache/cache_core/__init__.py
+++ b/dimagi/utils/couch/cache/cache_core/__init__.py
@@ -1,7 +1,9 @@
+import logging
 from django.conf import settings
 from django.core import cache
 from django.core.cache import InvalidCacheBackendError
 
+log = logging.getLogger(__name__)
 
 COUCH_CACHE_TIMEOUT = 43200
 MOCK_REDIS_CACHE = None
@@ -37,11 +39,10 @@ def get_redis_default_cache():
 def get_redis_client():
     from redis_cache.cache import RedisCache
     rcache = get_redis_default_cache()
-    if not isinstance(rcache, RedisCache):
-        raise RedisClientError("Could not get redis connection.")
     try:
         client = rcache.raw_client
-    except:
+    except Exception:
+        log.error("Could not get redis connection.", exc_info=True)
         raise RedisClientError("Could not get redis connection.")
     return client
 


### PR DESCRIPTION
- `isinstance(rcache, RedisCache)` was failing because Django debug toolbar wraps the redis cache in a proxy class.
- Log the error before swallowing it.
- Do not catch unrecoverable exceptions like `KeyboardInterrupt` and `SystemExit`.
