### PR TITLE
Do not drop query string on simple_post

### DIFF
--- a/dimagi/utils/post.py
+++ b/dimagi/utils/post.py
@@ -60,7 +60,7 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
     else:
         Connection = httplib.HTTPConnection
     conn = Connection(up.netloc, timeout=timeout)
-    conn.request('POST', up.path, data, default_headers)
+    conn.request('POST', url, data, default_headers)
     return conn.getresponse()
 
 


### PR DESCRIPTION
According to [the docs](https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.request) the parameter can be the entire URL, including query string parameters, not just the path.
