### PR TITLE
Don't try to call .lower() on None

### DIFF
--- a/dimagi/utils/excel.py
+++ b/dimagi/utils/excel.py
@@ -143,7 +143,7 @@ class IteratorJSONReader(object):
                     'false': False,
                     '': False,
                     None: False,
-                }[value.lower()]
+                }[value.lower() if hasattr(value, 'lower') else value]
             except KeyError:
                 raise JSONReaderError(
                     'Values for %s must be: "yes" or "no" (or empty = "no")' % field


### PR DESCRIPTION
@emord 
I found this while testing, then checked my inbox for "has no attribute lower" and saw this looks like an actual problem.

```
  File "submodules/dimagi-utils-src/dimagi/utils/excel.py", line 146, in set_field_value
    }[value.lower()]

AttributeError: 'NoneType' object has no attribute 'lower'
```
