### PR TITLE
Revert "cache exceptions too in lazy attachment"

### DIFF
--- a/dimagi/utils/couch/lazy_attachment_doc.py
+++ b/dimagi/utils/couch/lazy_attachment_doc.py
@@ -86,25 +86,10 @@ class LazyAttachmentDoc(Document):
             content = self._LAZY_ATTACHMENTS_CACHE[name]
         else:
             content = self.__get_cached_attachment(name)
-
             if not content:
-                try:
-                    content = self.fetch_attachment(name)
-                except Exception as e:
-                    # django cache will pickle this exception for you
-                    # but e.response isn't picklable
-                    if hasattr(e, 'response'):
-                        del e.response
-                    content = e
-                    raise
-                finally:
-                    self.__set_cached_attachment(name, content)
-                    self._LAZY_ATTACHMENTS_CACHE[name] = content
-            else:
-                self._LAZY_ATTACHMENTS_CACHE[name] = content
-
-        if isinstance(content, Exception):
-            raise content
+                content = self.fetch_attachment(name)
+                self.__set_cached_attachment(name, content)
+            self._LAZY_ATTACHMENTS_CACHE[name] = content
 
         return content
 


### PR DESCRIPTION
This reverts commit 9bca460a43be073d2558ecb9b5034fea240860c4.

this causes problems for temporal errors like couch timing out.

see: http://manage.dimagi.com/default.asp?150465
