### PR TITLE
remove unused imports

### DIFF
--- a/dimagi/utils/couch/debugdb/__init__.py
+++ b/dimagi/utils/couch/debugdb/__init__.py
@@ -7,16 +7,7 @@ import traceback
 import django
 from django.conf import settings
 
-from django.views.debug import linebreak_iter
-import couchdbkit
-from couchdbkit import resource, ResourceNotFound
-
-
 # -*- coding: utf-8 -
-from datetime import  datetime
-from couchdbkit.client import Database, ViewResults
-from django.utils.hashcompat import sha_constructor
-
 
 # Figure out some paths
 django_path = os.path.realpath(os.path.dirname(django.__file__))

--- a/dimagi/utils/django/cache.py
+++ b/dimagi/utils/django/cache.py
@@ -1,9 +1,9 @@
-from django.utils.hashcompat import md5_constructor
+import hashlib
 from django.utils.http import urlquote
 
 
 def make_template_fragment_key(fragment_name, vary_on):
     # Build a unicode key for this fragment and all vary-on's.
-    args = md5_constructor(u':'.join([urlquote(var) for var in vary_on]))
+    args = hashlib.md5(u':'.join([urlquote(var) for var in vary_on]))
     cache_key = 'template.cache.%s.%s' % (fragment_name, args.hexdigest())
     return cache_key


### PR DESCRIPTION
`from django.utils.hashcompat import sha_constructor` no longer exists