### PR TITLE
fix raw_post_data

### DIFF
--- a/dimagi/utils/couch/tastykit.py
+++ b/dimagi/utils/couch/tastykit.py
@@ -226,7 +226,7 @@ class CouchdbkitResource(Resource):
     #not implemented yet are the create/update/delete
     def obj_create(self, bundle, request=None, **kwargs):
         try:
-            j = simplejson.loads(request.raw_post_data)
+            j = simplejson.loads(request.body)
         except:
             pass
         bundle.obj = self._meta.doc_class.wrap(j)
@@ -240,7 +240,7 @@ class CouchdbkitResource(Resource):
         """
         Initial version works ok, though more verification is needed here
         """
-        j = simplejson.loads(request.raw_post_data)
+        j = simplejson.loads(request.body)
         res  = self._meta.doc_class.get_db().save_doc(j)
         bundle.obj = self._meta.doc_class.get(j['_id'])
         return bundle

--- a/dimagi/utils/decorators/view.py
+++ b/dimagi/utils/decorators/view.py
@@ -32,8 +32,8 @@ def get_file(filename):
                         if key != filename:
                             request.other_files[key] = item
                 else:
-                    # I have had some trouble with request.raw_post_data not preserving newlines...
-                    request.file = StringIO(request.raw_post_data)
+                    # I have had some trouble with request.body not preserving newlines...
+                    request.file = StringIO(request.body)
                     request.other_files = {}
             return view(request, *args, **kwargs)
         return view_prime


### PR DESCRIPTION
`HttpRequest.raw_post_data` was renamed to `body` in django 1.4: https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-1-6