### PR TITLE
filter out empty keys from bulk get_docs

### DIFF
--- a/dimagi/utils/couch/bulk.py
+++ b/dimagi/utils/couch/bulk.py
@@ -79,7 +79,7 @@ class CouchTransaction(object):
 
 
 def get_docs(db, keys):
-    payload = json.dumps({'keys': keys})
+    payload = json.dumps({'keys': filter(None, keys)})
     url = db.uri + '/_all_docs?include_docs=true'
 
     r = requests.post(url, data=payload,


### PR DESCRIPTION
None values cause ChunkedEncodingError: IncompleteRead on cloudant