### PR TITLE
Use REQUEST over POST/GET

### DIFF
--- a/dimagi/utils/decorators/datespan.py
+++ b/dimagi/utils/decorators/datespan.py
@@ -27,7 +27,7 @@ def datespan_in_request(from_param="from", to_param="to",
             # values, checking first the args and then the kwargs
             req = request_from_args_or_kwargs(*args, **kwargs)
             if req:
-                req_dict = req.POST if req.method == "POST" else req.GET
+                req_dict = req.REQUEST
                 def date_or_nothing(param):
                     date = req_dict.get(param, None)
                     return datetime.strptime(date, format_string) if date else None


### PR DESCRIPTION
This is a weird one, but this actually fixes this bug: http://manage.dimagi.com/default.asp?159628#887637

It isn't the only way to fix it but probably the least amount of intervention. The issue was that when making a POST call to get the report, the jquery data was being passed into the GET hash. So the method would be POST yet the data would be in the GET. This is the culprit: 
https://github.com/benrudolph/commcare-hq/blob/fix-setstate/corehq/apps/reports/static/reports/javascripts/reports.config.js#L46

The other option is to refactor `get_report_render_url`

@czue 