### PR TITLE
fix get_docs

### DIFF
--- a/dimagi/utils/couch/bulk.py
+++ b/dimagi/utils/couch/bulk.py
@@ -86,7 +86,7 @@ def get_docs(db, keys, **query_params):
     r = requests.post(url, data=payload,
                       headers={'content-type': 'application/json'},
                       auth=get_auth(url),
-                      params=query_params)
+                      **query_params)
 
     try:
         return r.json()['rows']


### PR DESCRIPTION
make usage of ```requests.post``` consistent with http://docs.python-requests.org/en/v0.10.6/api/#requests.post