### PR TITLE
pin django-redis to <=3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'jsonobject-couchdbkit',
         'django<1.7',
-        'django-redis',
+        'django-redis<=3.8',
         'mock>=0.8.0',
         'openpyxl',
         'Pillow',


### PR DESCRIPTION
they recently removed the redis_cache compatability layer

(todo: upgrade and import django_redis instead?)

This should fix the travis errors. (Wait for build!)