### PR TITLE
Allow omitted Z

### DIFF
--- a/dimagi/ext/jsonobject.py
+++ b/dimagi/ext/jsonobject.py
@@ -45,11 +45,15 @@ class DateTimeProperty(AbstractDateProperty):
         if '.' in value:
             fmt = ISO_DATETIME_FORMAT
             if len(value.split('.')[-1]) != 7:
-                raise ValueError(
-                    'USecDateTimeProperty '
-                    'must have 6 decimal places '
-                    'or none at all: {}'.format(value)
-                )
+                if value[-1] != 'Z':
+                    fmt = '%Y-%m-%dT%H:%M:%S.%f'
+                else:
+                    raise ValueError(
+                        'USecDateTimeProperty '
+                        'must have 6 decimal places '
+                        'or none at all: {}'.format(value)
+                    )
+
         else:
             fmt = HISTORICAL_DATETIME_FORMAT
 

--- a/dimagi/ext/tests/test_jsonobject.py
+++ b/dimagi/ext/tests/test_jsonobject.py
@@ -30,5 +30,11 @@ class TransitionalExactDateTimePropertyTest(SimpleTestCase):
             Foo.wrap({'bar': '2015-01-01T12:00:00'})
 
     def test_wrap_new_no_Z(self):
+        foo = Foo.wrap({'bar': '2015-01-01T12:00:00.120054'})
+        self.assertEqual(foo.bar, datetime.datetime(2015, 1, 1, 12, 0, 0,
+                                                    120054))
+        self.assertEqual(foo.to_json()['bar'], '2015-01-01T12:00:00.120054Z')
+
+    def test_wrap_new_too_long(self):
         with self.assertRaises(BadValueError):
-            Foo.wrap({'bar': '2015-01-01T12:00:00.120054'})
+            Foo.wrap({'bar': '2015-01-01T12:00:00.1200543'})


### PR DESCRIPTION
cf. [FB 167676][1]. 

This seems to be the right thing to do for now, but longer term I'm guessing we need to migrate the old data, and revert this change.

@snopoke, @dannyroberts, buddy ping @biyeun 

  [1]: http://manage.dimagi.com/default.asp?167676
