### PR TITLE
FileObject

### DIFF
--- a/dimagi/test_utils/__init__.py
+++ b/dimagi/test_utils/__init__.py
@@ -1,4 +1,3 @@
 from __future__ import absolute_import
 
 from .base import *
-from .cache_tests import *

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -179,8 +179,8 @@ class TemporaryObject(object):
         self.cache_key = cache_key
 
     def is_cached(self):
-        return self.rcache.exists(self.stream_key(OBJECT_ORIGINAL)) and self.rcache.exists(
-            self.meta_key(OBJECT_ORIGINAL))
+        return self.rcache.exists(os.path.join(self.stream_key(OBJECT_ORIGINAL))) and self.rcache.exists(
+            os.path.join(self.meta_key(OBJECT_ORIGINAL)))
 
     @property
     def key_prefix(self):

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -270,8 +270,8 @@ class FileObject(TemporaryObject):
         super(FileObject, self).__init__(cache_key)
 
     def is_cached(self):
-        return os.path.exists(self.base_dir, self.stream_key()) and os.path.exists(
-            self.base_dir, self.meta_key())
+        return os.path.exists(os.path.join(self.base_dir, self.stream_key())) and os.path.exists(
+            os.path.join(self.base_dir, self.meta_key()))
 
     def fetch_stream(self):
         stream_path = os.path.join(

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -178,13 +178,6 @@ class TemporaryObject(object):
         """
         self.cache_key = cache_key
 
-        try:
-            stream_keys, meta_keys = self.get_all_keys()
-            self.stream_keys = stream_keys
-            self.meta_keys = meta_keys
-        except AssertionError as e:
-            logging.exception(e.message)
-
     def is_cached(self):
         try:
             metas, streams = self.get_all_keys()
@@ -303,6 +296,10 @@ class FileObject(TemporaryObject):
     def __init__(self, cache_key, base_dir=None):
         self._base_dir = base_dir
         super(FileObject, self).__init__(cache_key)
+
+    def is_cached(self):
+        return os.path.exists(self.base_dir, self.stream_key()) and os.path.exists(
+            self.base_dir, self.meta_key())
 
     def fetch_stream(self):
         stream_path = os.path.join(

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -179,8 +179,8 @@ class TemporaryObject(object):
         self.cache_key = cache_key
 
     def is_cached(self):
-        return self.rcache.exists(os.path.join(self.stream_key(OBJECT_ORIGINAL))) and self.rcache.exists(
-            os.path.join(self.meta_key(OBJECT_ORIGINAL)))
+        return self.rcache.exists(self.stream_key(OBJECT_ORIGINAL)) and self.rcache.exists(
+            self.meta_key(OBJECT_ORIGINAL))
 
     @property
     def key_prefix(self):

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -329,6 +329,12 @@ class FileObject(TemporaryObject):
 
         return (meta, stream)
 
+    def get_stream_filepath(self):
+        return os.path.join(self.base_dir, self.stream_key())
+
+    def get_meta_filepath(self):
+        return os.path.join(self.base_dir, self.meta_key())
+
     @property
     def base_dir(self):
         return self._base_dir or settings.SHARED_DRIVE_CONF.temp_dir
@@ -343,8 +349,8 @@ class FileObject(TemporaryObject):
         if not base_dir:
             return
 
-        stream_path = os.path.join(base_dir, self.stream_key(OBJECT_ORIGINAL))
-        meta_path = os.path.join(base_dir, self.meta_key(OBJECT_ORIGINAL))
+        stream_path = self.get_stream_filepath()
+        meta_path = self.get_meta_filepath()
 
         with open(stream_path, 'w+') as f:
             f.write(object_stream.read())
@@ -355,6 +361,8 @@ class FileObject(TemporaryObject):
         """
         Returns all FULL keys
         """
+        if not self.base_dir:
+            return [], []
         full_stream_keys = glob.glob(os.path.join(self.base_dir, self.stream_key(WILDCARD)))
         full_meta_keys = glob.glob(os.path.join(self.base_dir, self.meta_key(WILDCARD)))
 

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -224,14 +224,6 @@ class TemporaryObject(object):
         """
         raise NotImplementedError()
 
-    def get_all_keys(self):
-        """
-        Gets all keys associated with the object.
-
-        Resturns two values: list_stream_keys, list_meta_keys
-        """
-        raise NotImplementedError()
-
 
 class CachedObject(TemporaryObject):
 
@@ -333,21 +325,6 @@ class FileObject(TemporaryObject):
             f.write(object_stream.read())
         with open(meta_path, 'w+') as f:
             f.write(simplejson.dumps(object_meta.to_json()))
-
-    def get_all_keys(self):
-        """
-        Returns all FULL keys
-        """
-        if not self.base_dir:
-            return [], []
-        full_stream_keys = glob.glob(os.path.join(self.base_dir, self.stream_key(WILDCARD)))
-        full_meta_keys = glob.glob(os.path.join(self.base_dir, self.meta_key(WILDCARD)))
-
-        assert len(full_stream_keys) == len(full_meta_keys),\
-            "Error stream and meta keys must be 1:1 - something went wrong in the configuration "\
-            "for key=%s, full_stream_keys=%s, full_meta_keys=%s"\
-            % (self.cache_key, str(full_stream_keys), str(full_meta_keys))
-        return full_stream_keys, full_meta_keys
 
 
 class CachedImage(CachedObject):

--- a/dimagi/utils/tests/__init__.py
+++ b/dimagi/utils/tests/__init__.py
@@ -18,3 +18,4 @@ from .name_to_url import *
 from .dates import *
 from .test_json_handler import *
 from .test_modules import *
+from .test_temporary_objects import *


### PR DESCRIPTION
@snopoke @czue this has been on my backlog for a while. This is the beginnings of trying to fix our redis queries that take 2+ minutes. I want to make a `FileObject` class that talks like the `CachedObject` so we can interchange them. That way we can use the `FileObject` to store a file like `media_profile` in the temp_dir on the NFS instead of in Redis. This PR is a pretty long way off in terms of cleanliness, I want to rejig some of the inheritance so it makes more sense to have the FileSystem as a backend instead of Redis. Let me know if you think this is worthwhile to pursue

buddy: @orangejenny 