### PR TITLE
Remove call to get_all_keys

### DIFF
--- a/dimagi/test_utils/cache_tests.py
+++ b/dimagi/test_utils/cache_tests.py
@@ -22,6 +22,9 @@ class FakeCache(object):
     def set(self, key, value, timeout=None):
         self.cache_dict[key] = value
 
+    def exists(self, key):
+        return key in self.cache_dict
+
 
 fake_cache = FakeCache()
 

--- a/dimagi/utils/django/cached_object.py
+++ b/dimagi/utils/django/cached_object.py
@@ -176,27 +176,9 @@ class CachedObject(object):
         """
         self.cache_key = cache_key
 
-        #key_hash is the hash of the key for eventual use as a retrieval via static assets.
-        #todo: once key_hash determined with object stream, create stream file and deposit onto static machine
-        #generate url and retrieve by key_hash url.
-        self.key_hash = hashlib.md5(cache_key).hexdigest()
-        try:
-            stream_keys, meta_keys = self.get_all_keys()
-            self.stream_keys = stream_keys
-            self.meta_keys = meta_keys
-        except AssertionError as e:
-            logging.exception(e.message)
-
     def is_cached(self):
-        try:
-            metas, streams = self.get_all_keys()
-            if len(metas) == 0:
-                return False
-            else:
-                return True
-        except AssertionError:
-            # maybe one of our keys was purged. Oh well.
-            return False
+        return self.rcache.exists(self.stream_key(OBJECT_ORIGINAL)) and self.rcache.exists(
+            self.meta_key(OBJECT_ORIGINAL))
 
     @property
     def key_prefix(self):
@@ -257,19 +239,6 @@ class CachedObject(object):
     def rcache(self):
         return MOCK_REDIS_CACHE or cache.get_cache('redis')
 
-    def get_all_keys(self):
-        """
-        Returns all FULL keys
-        """
-        full_stream_keys = self.rcache.keys(self.stream_key(WILDCARD))
-        full_meta_keys = self.rcache.keys(self.meta_key(WILDCARD))
-
-        assert len(full_stream_keys) == len(full_meta_keys),\
-            "Error stream and meta keys must be 1:1 - something went wrong in the configuration "\
-            "for key=%s, full_stream_keys=%s, full_meta_keys=%s"\
-            % (self.cache_key, str(full_stream_keys), str(full_meta_keys))
-        return full_stream_keys, full_meta_keys
-
 
 class CachedImage(CachedObject):
     """
@@ -288,6 +257,30 @@ class CachedImage(CachedObject):
 
         rcache.set(self.stream_key(OBJECT_ORIGINAL), image_stream.read())
         rcache.set(self.meta_key(OBJECT_ORIGINAL), simplejson.dumps(image_meta.to_json()))
+
+    def is_cached(self):
+        try:
+            metas, streams = self.get_all_keys()
+            if len(metas) == 0:
+                return False
+            else:
+                return True
+        except AssertionError:
+            # maybe one of our keys was purged. Oh well.
+            return False
+
+    def get_all_keys(self):
+        """
+        Returns all FULL keys
+        """
+        full_stream_keys = self.rcache.keys(self.stream_key(WILDCARD))
+        full_meta_keys = self.rcache.keys(self.meta_key(WILDCARD))
+
+        assert len(full_stream_keys) == len(full_meta_keys),\
+            "Error stream and meta keys must be 1:1 - something went wrong in the configuration "\
+            "for key=%s, full_stream_keys=%s, full_meta_keys=%s"\
+            % (self.cache_key, str(full_stream_keys), str(full_meta_keys))
+        return full_stream_keys, full_meta_keys
 
     def get(self, size_key=OBJECT_ORIGINAL, **kwargs):
         """


### PR DESCRIPTION
@orangejenny @snopoke just pulled out the call to check all keys. it's a slow call that is [O(N)](http://redis.io/commands/KEYS) with # of keys in the database. hence the reason our slow log looks like this:
<img width="684" alt="screen shot 2015-07-31 at 1 10 14 pm" src="https://cloud.githubusercontent.com/assets/918514/9002761/8339b33c-3785-11e5-8821-6ffe1dab37c9.png">
All calls to KEYS
