### PR TITLE
name_to_url default string & unicode tests

### DIFF
--- a/dimagi/utils/name_to_url.py
+++ b/dimagi/utils/name_to_url.py
@@ -1,4 +1,9 @@
 import re
 
-def name_to_url(name):
-    return re.sub(r'[^0-9a-z]+', '-', name.strip().lower())
+def name_to_url(name, default=""):
+    url = re.sub(r'[^0-9a-z]+', '-', name.strip().lower())
+    if re.search('^[0-9\-]*$', url) and default:
+        url = "{}-{}".format(default, url)
+    url = re.sub(r'^-+', '', url)
+    url = re.sub(r'-+$', '', url)
+    return url

--- a/dimagi/utils/name_to_url.py
+++ b/dimagi/utils/name_to_url.py
@@ -4,6 +4,5 @@ def name_to_url(name, default=""):
     url = re.sub(r'[^0-9a-z]+', '-', name.strip().lower())
     if re.search('^[0-9\-]*$', url) and default:
         url = "{}-{}".format(default, url)
-    url = re.sub(r'^-+', '', url)
-    url = re.sub(r'-+$', '', url)
+    url = url.strip("-")
     return url

--- a/dimagi/utils/tests/name_to_url.py
+++ b/dimagi/utils/tests/name_to_url.py
@@ -4,3 +4,6 @@ from dimagi.utils.name_to_url import name_to_url
 class NameToURLTest(SimpleTestCase):
     def test_name_to_url(self):
         self.assertEquals(name_to_url("I have  spaces"), "i-have-spaces")
+        self.assertEquals(name_to_url(u"\u00f5", "project"), "project")
+        self.assertEquals(name_to_url(u"thing \u00f5", "project"), "thing")
+        self.assertEquals(name_to_url(u"abc \u00f5 def"), "abc-def")


### PR DESCRIPTION
support https://github.com/dimagi/commcare-hq/pull/8255

drop preceding/trailing hyphens, and add a prefix string if the generated string is all numbers/hyphens

@emord / @kaapstorm 