### PR TITLE
Allow DateSpan to set a max number of days

### DIFF
--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import datetime
 from calendar import month_name
+from django.utils.translation import ugettext_lazy as _
 import logging
 
 try:
@@ -312,16 +314,17 @@ class DateSpan(object):
     
     def get_validation_reason(self):
         if self.startdate is None or self.enddate is None:
-            return "You have to specify both dates!"
+            return _("You have to specify both dates!")
         elif self.enddate < self.startdate:
-            return "You can't have an end date of %s after start date of %s" % (self.enddate, self.startdate)
+            return _("You can't have an end date of {end} after start date of {start}").format(
+                end=self.enddate, start=self.startdate)
         elif self.startdate < datetime.datetime(1900, 01, 01) or self.enddate < datetime.datetime(1900, 01, 01):
-            return "You can't use dates earlier than the year 1900"
+            return _("You can't use dates earlier than the year 1900")
         elif self.max_days is not None:
             delta = self.enddate - self.startdate
             if delta.days > self.max_days:
-                return "You are limited to a span of {} days, but this date range spans {} days".format(
-                    self.max_days, delta.days)
+                return _("You are limited to a span of {max} days, but this date range spans {total} days").format(
+                    max=self.max_days, total=delta.days)
         return ""
     
     def __str__(self):

--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -136,14 +136,16 @@ class DateSpan(object):
     format = None
     inclusive = True
     is_default = False
-    max_days = -1
+    max_days = None
 
-    def __init__(self, startdate, enddate, format=ISO_DATE_FORMAT, inclusive=True, timezone=pytz.utc):
+    def __init__(self, startdate, enddate, format=ISO_DATE_FORMAT, inclusive=True, timezone=pytz.utc,
+                 max_days=None):
         self.startdate = startdate
         self.enddate = enddate
         self.format = format
         self.inclusive = inclusive
         self.timezone = timezone
+        self.max_days = max_days
 
     def __getstate__(self):
         """
@@ -173,7 +175,7 @@ class DateSpan(object):
         self.inclusive = state.get('inclusive', True)
         self.timezone = pytz.utc
         self.is_default = state.get('is_default', False)
-        self.max_days = state.get('max_days', -1)
+        self.max_days = state.get('max_days')
         try:
             self.timezone = pytz.timezone(state.get('timezone'))
         except Exception as e:

--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -136,7 +136,7 @@ class DateSpan(object):
     format = None
     inclusive = True
     is_default = False
-    max_days = None
+    _max_days = None
 
     def __init__(self, startdate, enddate, format=ISO_DATE_FORMAT, inclusive=True, timezone=pytz.utc,
                  max_days=None):
@@ -181,6 +181,15 @@ class DateSpan(object):
         except Exception as e:
             logging.error("Could not unpack timezone for DateSpan. Error: %s" % e)
 
+    @property
+    def max_days(self):
+        return self._max_days
+
+    @max_days.setter
+    def max_days(self, value):
+        if value is not None and value < 0:
+            raise ValueError('max_days cannot be less than 0')
+        self._max_days = value
 
     def to_dict(self):
         return {
@@ -308,7 +317,7 @@ class DateSpan(object):
             return "You can't have an end date of %s after start date of %s" % (self.enddate, self.startdate)
         elif self.startdate < datetime.datetime(1900, 01, 01) or self.enddate < datetime.datetime(1900, 01, 01):
             return "You can't use dates earlier than the year 1900"
-        elif self.max_days >= 0:
+        elif self.max_days is not None:
             delta = self.enddate - self.startdate
             if delta.days > self.max_days:
                 return "You are limited to a span of {} days, but this date range spans {} days".format(

--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -136,6 +136,7 @@ class DateSpan(object):
     format = None
     inclusive = True
     is_default = False
+    max_days = -1
 
     def __init__(self, startdate, enddate, format=ISO_DATE_FORMAT, inclusive=True, timezone=pytz.utc):
         self.startdate = startdate
@@ -154,7 +155,8 @@ class DateSpan(object):
             format=self.format,
             inclusive=self.inclusive,
             is_default=self.is_default,
-            timezone=self.timezone.zone
+            timezone=self.timezone.zone,
+            max_days=self.max_days,
         )
 
     def __setstate__(self, state):
@@ -171,6 +173,7 @@ class DateSpan(object):
         self.inclusive = state.get('inclusive', True)
         self.timezone = pytz.utc
         self.is_default = state.get('is_default', False)
+        self.max_days = state.get('max_days', -1)
         try:
             self.timezone = pytz.timezone(state.get('timezone'))
         except Exception as e:
@@ -303,6 +306,11 @@ class DateSpan(object):
             return "You can't have an end date of %s after start date of %s" % (self.enddate, self.startdate)
         elif self.startdate < datetime.datetime(1900, 01, 01) or self.enddate < datetime.datetime(1900, 01, 01):
             return "You can't use dates earlier than the year 1900"
+        elif self.max_days >= 0:
+            delta = self.enddate - self.startdate
+            if delta.days > self.max_days:
+                return "You are limited to a span of {} days, but this date range spans {} days".format(
+                    self.max_days, delta.days)
         return ""
     
     def __str__(self):

--- a/dimagi/utils/tests/dates.py
+++ b/dimagi/utils/tests/dates.py
@@ -108,3 +108,41 @@ class DateSpanInRequestTest(SimpleTestCase):
         self.assertIsInstance(datespan, DateSpan)
         self.assertEqual(datespan.enddate, end_date)
         self.assertEqual(datespan.startdate, start_date)
+
+
+class DateSpanValidationTests(SimpleTestCase):
+
+    def test_ok(self):
+        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 02, 01))
+        self.assertTrue(datespan.is_valid())
+        self.assertEqual(datespan.get_validation_reason(), "")
+
+    def test_date_missing(self):
+        datespan = DateSpan(datetime(2015, 01, 01), None)
+        self.assertFalse(datespan.is_valid())
+        self.assertEqual(datespan.get_validation_reason(), "You have to specify both dates!")
+
+    def test_end_before_start(self):
+        startdate = datetime(2015, 02, 01)
+        enddate = datetime(2015, 01, 01)
+        datespan = DateSpan(startdate, enddate)
+        self.assertFalse(datespan.is_valid())
+        self.assertEqual(datespan.get_validation_reason(),
+                         "You can't have an end date of %s after start date of %s" % (enddate, startdate))
+
+    def test_wrong_century(self):
+        datespan = DateSpan(datetime(1815, 01, 01), datetime(1815, 02, 01))
+        self.assertFalse(datespan.is_valid())
+        self.assertEqual(datespan.get_validation_reason(), "You can't use dates earlier than the year 1900")
+
+    def test_datespan_ok(self):
+        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 04, 01))
+        datespan.max_days = 90
+        self.assertTrue(datespan.is_valid())
+
+    def test_datespan_too_long(self):
+        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 07, 01))
+        datespan.max_days = 90
+        self.assertFalse(datespan.is_valid())
+        self.assertEqual(datespan.get_validation_reason(),
+                         "You are limited to a span of 90 days, but this date range spans 181 days")

--- a/dimagi/utils/tests/dates.py
+++ b/dimagi/utils/tests/dates.py
@@ -136,13 +136,15 @@ class DateSpanValidationTests(SimpleTestCase):
         self.assertEqual(datespan.get_validation_reason(), "You can't use dates earlier than the year 1900")
 
     def test_datespan_ok(self):
-        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 04, 01))
-        datespan.max_days = 90
+        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 04, 01), max_days=90)
         self.assertTrue(datespan.is_valid())
 
     def test_datespan_too_long(self):
-        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 07, 01))
-        datespan.max_days = 90
+        datespan = DateSpan(datetime(2015, 01, 01), datetime(2015, 07, 01), max_days=90)
         self.assertFalse(datespan.is_valid())
         self.assertEqual(datespan.get_validation_reason(),
                          "You are limited to a span of 90 days, but this date range spans 181 days")
+
+    def test_negative_max_days(self):
+        with self.assertRaisesRegexp(ValueError, 'max_days cannot be less than 0'):
+            DateSpan(datetime(2015, 01, 01), datetime(2015, 04, 01), max_days=-1)


### PR DESCRIPTION
This works towards allowing DailyFormStatsReport to set a maximum date span, to avoid errors caused by massive DataTable async request headers.

Context: [FB 185304](http://manage.dimagi.com/default.asp?185304)

@snopoke, @czue, cc @millerdev 
