### PR TITLE
Fix django 1.7 warning

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,8 @@ INSTALLED_APPS = (
     'django.contrib.auth',
 )
 
+MIDDLEWARE_CLASSES = ()
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This warning was being spewed a bunch of times when running tests:
```
System check identified some issues:

WARNINGS:
?: (1_7.W001) MIDDLEWARE_CLASSES is not set.
	HINT: Django 1.7 changed the global defaults for the MIDDLEWARE_CLASSES. django.contrib.sessions.middleware.SessionMiddleware, django.contrib.auth.middleware.AuthenticationMiddleware, and django.contrib.messages.middleware.MessageMiddleware were removed from the defaults. If your project needs these middleware then you should configure this setting.
```
@kaapstorm or anyone