### PR TITLE
fix generational caching

### DIFF
--- a/dimagi/utils/couch/cache/cache_core/gen.py
+++ b/dimagi/utils/couch/cache/cache_core/gen.py
@@ -50,7 +50,7 @@ class GenerationCache(object):
         genret = rcache().get(self.generation_key, None)
         if not genret:
             # never seen key before, start from zero
-            rcache().set(self.generation_key, 0, timeout=0)
+            rcache().set(self.generation_key, 0, timeout=None)
             return str(0)
         else:
             return str(genret)


### PR DESCRIPTION
in a previous version about django (haven’t quite pinpointed it,
but there were changes very similar to this noted in release notes
for django 1.6 and 1.7) timeout=0 meant "use the default timeout",
whereas now in 1.7 it means "expire immediately". This meant that
the code the bootstrapped the generational cache generation and
set it to 0 if it didn’t persist in the cache, and thus any new
cache would be perpetually have a generation of the original value
of 0.

should fix http://manage.dimagi.com/default.asp?188411