### PR TITLE
remove unused Site import

### DIFF
--- a/dimagi/utils/web.py
+++ b/dimagi/utils/web.py
@@ -12,7 +12,6 @@ from django.http import HttpResponse
 from django.template import RequestContext
 from django.shortcuts import render_to_response as django_r_to_r
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
-from django.contrib.sites.models import Site
 import json
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise


### PR DESCRIPTION
This'll get rid of the
```
/Users/droberts/.virtualenvs/cchq/lib/python2.7/site-packages/django/contrib/sites/models.py:65: RemovedInDjango19Warning: Model class django.contrib.sites.models.Site doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Site(models.Model):
```

that we see at the beginning of every management command