### PR TITLE
Use case insensitive dict

### DIFF
--- a/dimagi/utils/post.py
+++ b/dimagi/utils/post.py
@@ -50,10 +50,10 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
     """
     if isinstance(data, unicode):
         data = data.encode('utf-8')  # can't pass unicode to http request posts
-    default_headers = {
+    default_headers = requests.structures.CaseInsensitiveDict({
         "content-type": content_type,
         "content-length": len(data),
-    }
+    })
     if headers:
         default_headers.update(headers)
 


### PR DESCRIPTION
@czue @TylerSheffels 
essentially we were setting a dictionary with headers:
```
{
  content-type: 'text/xml'
  Content-type: 'application/json'
}
```
this bug only appeared because `requests` handled it differently than the previous setup. 