### PR TITLE
adding flag to track email opens via ga

### DIFF
--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -38,7 +38,6 @@ def send_HTML_email(subject, recipient, html_content, text_content=None,
             ga_tid=settings.ANALYTICS_IDS['GOOGLE_ANALYTICS_ID'],
             ga_cid=uuid.uuid4().hex)
         new_content = '<img src="{url}&ea=open"/>\n</body>'.format(url=url)
-        import ipdb; ipdb.set_trace()
         html_content = re.sub(r'(.*)</body>', r'\1'+new_content, html_content)
 
     from_header = {'From': email_from}  # From-header

--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -38,7 +38,8 @@ def send_HTML_email(subject, recipient, html_content, text_content=None,
             ga_tid=settings.ANALYTICS_IDS['GOOGLE_ANALYTICS_ID'],
             ga_cid=uuid.uuid4().hex)
         new_content = '<img src="{url}&ea=open"/>\n</body>'.format(url=url)
-        html_content = re.sub(r'(.*)</body>', new_content+r'\1', html_content)
+        import ipdb; ipdb.set_trace()
+        html_content = re.sub(r'(.*)</body>', r'\1'+new_content, html_content)
 
     from_header = {'From': email_from}  # From-header
     connection = get_connection()

--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -38,7 +38,9 @@ def send_HTML_email(subject, recipient, html_content, text_content=None,
             ga_tid=settings.ANALYTICS_IDS['GOOGLE_ANALYTICS_ID'],
             ga_cid=uuid.uuid4().hex)
         new_content = '<img src="{url}&ea=open"/>\n</body>'.format(url=url)
-        html_content = re.sub(r'(.*)</body>', r'\1'+new_content, html_content)
+        html_content, count = re.subn(r'(.*)</body>', r'\1'+new_content, html_content)
+        if count == 0:
+            raise Exception('Cannot add tracking to HTML Email with no closing body tag')
 
     from_header = {'From': email_from}  # From-header
     connection = get_connection()

--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -1,6 +1,7 @@
 from smtplib import SMTPSenderRefused
 import uuid
 import requests
+import re
 from django.conf import settings
 from django.core.mail import get_connection
 from django.core.mail.message import EmailMultiAlternatives
@@ -37,7 +38,7 @@ def send_HTML_email(subject, recipient, html_content, text_content=None,
             ga_tid=settings.ANALYTICS_IDS['GOOGLE_ANALYTICS_ID'],
             ga_cid=uuid.uuid4().hex)
         new_content = '<img src="{url}&ea=open"/>\n</body>'.format(url=url)
-        html_content = html_content.replace('</body>', new_content)
+        html_content = re.sub(r'(.*)</body>', new_content+r'\1', html_content)
 
     from_header = {'From': email_from}  # From-header
     connection = get_connection()

--- a/dimagi/utils/django/email.py
+++ b/dimagi/utils/django/email.py
@@ -39,8 +39,7 @@ def send_HTML_email(subject, recipient, html_content, text_content=None,
             ga_cid=uuid.uuid4().hex)
         new_content = '<img src="{url}&ea=open"/>\n</body>'.format(url=url)
         html_content, count = re.subn(r'(.*)</body>', r'\1'+new_content, html_content)
-        if count == 0:
-            raise Exception('Cannot add tracking to HTML Email with no closing body tag')
+        assert count != 0, 'Attempted to add tracking to HTML Email with no closing body tag'
 
     from_header = {'From': email_from}  # From-header
     connection = get_connection()


### PR DESCRIPTION
@czue @millerdev 
This adds the ability to track the open rate of our emails, by sending a request to google analytics upon sending, and adding an empty image that hits GA upon open.