### PR TITLE
Fix datetime check

### DIFF
--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -125,7 +125,7 @@ def utcnow_sans_milliseconds():
 
 def today_or_tomorrow(date, inclusive=True):
     today = datetime.datetime.combine(datetime.datetime.today(), datetime.time())
-    if isinstance(date, datetime.date):
+    if type(date) is datetime.date:
         today = today.date()
     day_after_tomorrow = today + datetime.timedelta(days=2)
 


### PR DESCRIPTION
@sravfeyn @proteusvacuum i think this is what the previous check meant to do. since `datetime` is a subclass of `date` that `if` statement always evaluates to true:

```
In [3]: issubclass(datetime.datetime, datetime.date)
Out[3]: True
```
http://manage.dimagi.com/default.asp?231865#1180917