### PR TITLE
Add safe generator

### DIFF
--- a/dimagi/utils/tests/database.py
+++ b/dimagi/utils/tests/database.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+
+from dimagi.utils.couch.database import SafeGenerator, GeneratorAlreadyConsumedException
+
+
+class SafeGeneratorTest(SimpleTestCase):
+
+    def test_exception(self):
+        generator = (x for x in range(3))
+        safe_generator = SafeGenerator(generator)
+        self.assertEqual(list(safe_generator), [0,1,2])
+        with self.assertRaises(GeneratorAlreadyConsumedException):
+            for i in safe_generator:
+                pass


### PR DESCRIPTION
Add a `SafeGenerator` class, which can be used to wrap a normal generator. It will throw an exception if something attempts to iterate over the generator a second time.
This PR also adds a decorator that can be used with functions that return generators so that they will return SafeGenerators instead.
@czue @esoergel 