### PR TITLE
raise exception if lock not acquired

### DIFF
--- a/dimagi/utils/couch/__init__.py
+++ b/dimagi/utils/couch/__init__.py
@@ -72,13 +72,16 @@ class ReleaseOnError(object):
 
 
 def acquire_lock(lock, degrade_gracefully, **kwargs):
+    acquired = False
     try:
-        lock.acquire(**kwargs)
+        acquired = lock.acquire(**kwargs)
     except RedisError:
         if degrade_gracefully:
             lock = None
         else:
             raise
+    if lock and not acquired and not degrade_gracefully:
+        raise RedisError("Unable to acquire lock")
     return lock
 
 


### PR DESCRIPTION
If the `blocking_timeout` is reached before the lock is acquired then `lock.acquire` return False.

I know we don't use `blocking_timeout` much but seems safe to have this if we ever do