### PR TITLE
fix type check for date

### DIFF
--- a/dimagi/utils/dates.py
+++ b/dimagi/utils/dates.py
@@ -125,7 +125,7 @@ def utcnow_sans_milliseconds():
 
 def today_or_tomorrow(date, inclusive=True):
     today = datetime.datetime.combine(datetime.datetime.today(), datetime.time())
-    if isinstance(date, datetime.date):
+    if type(date) == datetime.date:
         today = today.date()
     day_after_tomorrow = today + datetime.timedelta(days=2)
 


### PR DESCRIPTION
isinstance check for a datetime.datetime object gives a false positive with datetime.date since the former is inherited from the latter so update to check for object type instead
Resolves: http://manage.dimagi.com/default.asp?248226, http://manage.dimagi.com/default.asp?248228