### PR TITLE
Use timeout param

### DIFF
--- a/dimagi/utils/post.py
+++ b/dimagi/utils/post.py
@@ -57,8 +57,8 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
     return requests.post(url, data, headers=default_headers, timeout=timeout)
 
 
-def post_data(data, url, curl_command="curl", use_curl=False, 
-              content_type="text/xml", path=None, use_chunked=False, 
+def post_data(data, url, curl_command="curl", use_curl=False,
+              content_type="text/xml", path=None, use_chunked=False,
               is_odk=False, attachments=None):
     """
     Do a POST of data with some options.  Returns a tuple of the response

--- a/dimagi/utils/post.py
+++ b/dimagi/utils/post.py
@@ -54,8 +54,7 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None):
     })
     if headers:
         default_headers.update(headers)
-
-    return requests.post(url, data, headers=default_headers)
+    return requests.post(url, data, headers=default_headers, timeout=timeout)
 
 
 def post_data(data, url, curl_command="curl", use_curl=False, 


### PR DESCRIPTION
I believe this has been negatively affecting repeater performance, where it is common for people to give us URLs that hang indefinitely.